### PR TITLE
Fix model and view versions to match between Python and JS

### DIFF
--- a/{{cookiecutter.github_project_name}}/src/plugin.ts
+++ b/{{cookiecutter.github_project_name}}/src/plugin.ts
@@ -18,9 +18,8 @@ import {
 } from './widget';
 
 import {
-  JUPYTER_EXTENSION_VERSION
+  EXTENSION_SPEC_VERSION
 } from './version';
-
 
 const EXTENSION_ID = '{{ cookiecutter.jlab_extension_id }}';
 
@@ -44,7 +43,7 @@ export default examplePlugin;
 function activateWidgetExtension(app: Application<Widget>, registry: IJupyterWidgetRegistry): void {
   registry.registerWidget({
     name: '{{ cookiecutter.npm_package_name }}',
-    version: JUPYTER_EXTENSION_VERSION,
+    version: EXTENSION_SPEC_VERSION,
     exports: {
       ExampleModel: ExampleModel,
       ExampleView: ExampleView

--- a/{{cookiecutter.github_project_name}}/src/version.ts
+++ b/{{cookiecutter.github_project_name}}/src/version.ts
@@ -10,4 +10,4 @@
  * your models, or serialized format changes.
  */
 export
-const JUPYTER_EXTENSION_VERSION = '1.0.0';
+const EXTENSION_SPEC_VERSION = '1.0.0';

--- a/{{cookiecutter.github_project_name}}/src/widget.ts
+++ b/{{cookiecutter.github_project_name}}/src/widget.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyter-widgets/base';
 
 import {
-  JUPYTER_EXTENSION_VERSION
+  EXTENSION_SPEC_VERSION
 } from './version';
 
 
@@ -31,10 +31,10 @@ class ExampleModel extends DOMWidgetModel {
 
   static model_name = 'ExampleModel';
   static model_module = '{{ cookiecutter.npm_package_name }}';
-  static model_module_version = JUPYTER_EXTENSION_VERSION;
+  static model_module_version = EXTENSION_SPEC_VERSION;
   static view_name = 'ExampleView';  // Set to null if no view
   static view_module = '{{ cookiecutter.npm_package_name }}';   // Set to null if no view
-  static view_module_version = JUPYTER_EXTENSION_VERSION;
+  static view_module_version = EXTENSION_SPEC_VERSION;
 }
 
 

--- a/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/_version.py
+++ b/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/_version.py
@@ -6,3 +6,11 @@
 
 version_info = (0, 1, 0, 'dev')
 __version__ = ".".join(map(str, version_info))
+
+# The version of the attribute spec that this package
+# implements. This is the value used in
+# _model_module_version/_view_module_version.
+#
+# Update this value when attributes are added/removed from
+# your models, or serialized format changes.
+EXTENSION_SPEC_VERSION = '1.0.0'

--- a/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/example.py
+++ b/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/example.py
@@ -10,19 +10,19 @@ TODO: Add module docstring
 
 from ipywidgets import DOMWidget
 from traitlets import Unicode
+from ._version import EXTENSION_SPEC_VERSION
 
 module_name = "{{ cookiecutter.npm_package_name }}"
-module_version = "{{ cookiecutter.npm_package_version }}"
 
 
 class ExampleWidget(DOMWidget):
     """TODO: Add docstring here
     """
-    _model_name =  Unicode('ExampleModel').tag(sync=True)
+    _model_name = Unicode('ExampleModel').tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
-    _model_module_version = Unicode(module_version).tag(sync=True)
-    _view_name =  Unicode('ExampleView').tag(sync=True)
+    _model_module_version = Unicode(EXTENSION_SPEC_VERSION).tag(sync=True)
+    _view_name = Unicode('ExampleView').tag(sync=True)
     _view_module = Unicode(module_name).tag(sync=True)
-    _view_module_version = Unicode(module_version).tag(sync=True)
+    _view_module_version = Unicode(EXTENSION_SPEC_VERSION).tag(sync=True)
 
     value = Unicode('Hello World')


### PR DESCRIPTION
As discussed with @vidartf on Gitter

@jasongrout suggested not using PROTOCOL_VERSION which refers to the actual serialization version, and instead using something like SPEC_VERSION